### PR TITLE
Fix typo in Game.ts

### DIFF
--- a/cave-game/server/Game.ts
+++ b/cave-game/server/Game.ts
@@ -387,7 +387,7 @@ export class Game implements ServerHandlers<ClientMessage, ServerMessage> {
 	 * resolved once a player joins. becomes a new `Promise` object when all players leave
 	 *
 	 * used to pause the game when no one is online so (a) objects dont fall infinitely (there's no floor rn)
-	 * and (b) to conserve resources. we love the nevironment
+        * and (b) to conserve resources. we love the environment
 	 */
 	get hasPlayers() {
 		return this.server.hasConnection;

--- a/gpt.txt
+++ b/gpt.txt
@@ -1,3 +1,4 @@
 Prompt: Generate (necessary and unnecessary) todo items as bullet points for each commit to guess what the committer should do next that excludes what the committer did in the current commit. You must format your response as a markdown file that will act as release notes. ⚠️!!!Do not include lists of filenames in your response!!!⚠️
 
 Response: This is my first rain day
+Additional text for commit testing.


### PR DESCRIPTION
## Summary
- fix a small typo in the Game.ts comment around line 390
- add a short note to gpt.txt

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b6ac70d688320bf22659ce412df5f