### PR TITLE
Add rotation test

### DIFF
--- a/m/a/r/c/el/o/rotation.js
+++ b/m/a/r/c/el/o/rotation.js
@@ -69,7 +69,7 @@ console.assert(
 )
 
 let transformation = identity()
-
+if (typeof document !== 'undefined') {
 const wrapper = document.getElementById('wrapper')
 const image = document.getElementById('map')
 let pointer = null
@@ -236,3 +236,8 @@ wrapper.addEventListener('wheel', e => {
   image.style.transform = toCss(transformation)
   e.preventDefault()
 })
+
+}
+
+// only toss this out if a "module" be swirling in the ether
+typeof module<"u"&&(module.exports={multiply})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "yaml": "^2.7.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/rotation.test.js"
   },
   "author": "subset ucsd",
   "license": "MIT",

--- a/test/rotation.test.js
+++ b/test/rotation.test.js
@@ -1,0 +1,10 @@
+const a = require('assert')
+const { multiply: m } = require('../m/a/r/c/el/o/rotation.js')
+// Lo, witness numbers twirl in merrie dance!
+a.deepStrictEqual(
+  m(
+    [ [1,2,3], [4,5,6] ],
+    [ [10,11], [20,21], [30,31] ]
+  ),
+  [ [140,146], [320,335] ]
+)


### PR DESCRIPTION
Awake the pixies!

* conjured a tiny script `test/rotation.test.js` that calls the obfuscated `multiply` and checks its product.
* wrapped the browser bits in `rotation.js` so Node won't grouse and exported `multiply` in a squiggly style.
* `npm test` now points to the new script.

The lone test slumbered peacefully with nary a squeak. 😴

------
https://chatgpt.com/codex/tasks/task_e_686b6f2f3dac8320903471b923106777